### PR TITLE
Add setup for API tests and Roman numerals test cases

### DIFF
--- a/.github/workflows/api-tests.yaml
+++ b/.github/workflows/api-tests.yaml
@@ -1,0 +1,35 @@
+name: API Tests - httpYac
+
+on:
+  workflow_dispatch:
+permissions:
+  contents: read
+  actions: read
+  checks: write
+  issues: read
+  pull-requests: write
+jobs:
+  run_httpyac_api_tests:
+    name: API Tests by httpYac
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install dependencies and run tests
+        run: |
+          npm install
+          npm run api-test
+
+      - name: Publish Test Report
+        uses: dorny/test-reporter@v1
+        if: success() || failure()          # run this step even if previous step failed
+        with:
+          name: httpYac API Tests           # Name of the check run which will be created
+          path: report.xml          # Path to test results
+          reporter: java-junit              # Format of test results
+
+      - name: Publish API Test Results
+        uses: EnricoMi/publish-unit-test-result-action@v2
+        if: always()
+        with:
+          check_name: API Tests by httpYac
+          junit_files: report.xml

--- a/http-client.env.json
+++ b/http-client.env.json
@@ -1,0 +1,8 @@
+{
+  "local": {
+    "host": "http://localhost:7071"
+  },
+  "azure": {
+    "host": "https://exercism.azurewebsites.net"
+  }
+}

--- a/load-test-data.js
+++ b/load-test-data.js
@@ -1,0 +1,15 @@
+const fs = require('fs');
+const path = require('path');
+
+function loadTestData(fileName) {
+    const filePath = path.join(__dirname, fileName);
+    const rawData = fs.readFileSync(filePath);
+    const jsonData = JSON.parse(rawData);
+    return jsonData.cases.map(testCase => ({
+        description: testCase.description,
+        number: testCase.input.number,
+        expected: testCase.expected
+    }));
+}
+
+module.exports = loadTestData;

--- a/roman-numerals/roman-numerals-test-cases.json
+++ b/roman-numerals/roman-numerals-test-cases.json
@@ -1,0 +1,265 @@
+{
+    "exercise": "roman-numerals",
+    "cases": [
+      {
+        "uuid": "19828a3a-fbf7-4661-8ddd-cbaeee0e2178",
+        "description": "1 is I",
+        "property": "roman",
+        "input": {
+          "number": 1
+        },
+        "expected": "I"
+      },
+      {
+        "uuid": "f088f064-2d35-4476-9a41-f576da3f7b03",
+        "description": "2 is II",
+        "property": "roman",
+        "input": {
+          "number": 2
+        },
+        "expected": "II"
+      },
+      {
+        "uuid": "b374a79c-3bea-43e6-8db8-1286f79c7106",
+        "description": "3 is III",
+        "property": "roman",
+        "input": {
+          "number": 3
+        },
+        "expected": "III"
+      },
+      {
+        "uuid": "05a0a1d4-a140-4db1-82e8-fcc21fdb49bb",
+        "description": "4 is IV",
+        "comments": ["Because 4 is 5 - 1"],
+        "property": "roman",
+        "input": {
+          "number": 4
+        },
+        "expected": "IV"
+      },
+      {
+        "uuid": "57c0f9ad-5024-46ab-975d-de18c430b290",
+        "description": "5 is V",
+        "property": "roman",
+        "input": {
+          "number": 5
+        },
+        "expected": "V"
+      },
+      {
+        "uuid": "20a2b47f-e57f-4797-a541-0b3825d7f249",
+        "description": "6 is VI",
+        "comments": ["Because 6 is 5 + 1"],
+        "property": "roman",
+        "input": {
+          "number": 6
+        },
+        "expected": "VI"
+      },
+      {
+        "uuid": "ff3fb08c-4917-4aab-9f4e-d663491d083d",
+        "description": "9 is IX",
+        "comments": ["Because 9 is 10 - 1"],
+        "property": "roman",
+        "input": {
+          "number": 9
+        },
+        "expected": "IX"
+      },
+      {
+        "uuid": "6d1d82d5-bf3e-48af-9139-87d7165ed509",
+        "description": "16 is XVI",
+        "comments": [
+          "16 has exactly one occurence of all symbols whose value is less than 50 (L) in decreasing order"
+        ],
+        "property": "roman",
+        "input": {
+          "number": 16
+        },
+        "expected": "XVI"
+      },
+      {
+        "uuid": "2bda64ca-7d28-4c56-b08d-16ce65716cf6",
+        "description": "27 is XXVII",
+        "property": "roman",
+        "input": {
+          "number": 27
+        },
+        "expected": "XXVII"
+      },
+      {
+        "uuid": "a1f812ef-84da-4e02-b4f0-89c907d0962c",
+        "description": "48 is XLVIII",
+        "comments": ["Because 48 is not 50 - 2, but rather 40 + 8"],
+        "property": "roman",
+        "input": {
+          "number": 48
+        },
+        "expected": "XLVIII"
+      },
+      {
+        "uuid": "607ead62-23d6-4c11-a396-ef821e2e5f75",
+        "description": "49 is XLIX",
+        "comments": [
+          "Because 49 is not 40 + 5 + 4, but rather (50 - 10) + (10 - 1)"
+        ],
+        "property": "roman",
+        "input": {
+          "number": 49
+        },
+        "expected": "XLIX"
+      },
+      {
+        "uuid": "d5b283d4-455d-4e68-aacf-add6c4b51915",
+        "description": "59 is LIX",
+        "property": "roman",
+        "input": {
+          "number": 59
+        },
+        "expected": "LIX"
+      },
+      {
+        "uuid": "4465ffd5-34dc-44f3-ada5-56f5007b6dad",
+        "description": "66 is LXVI",
+        "comments": [
+          "66 has exactly one occurence of all symbols whose value is less than 100 (C) in decreasing order"
+        ],
+        "property": "roman",
+        "input": {
+          "number": 66
+        },
+        "expected": "LXVI"
+      },
+      {
+        "uuid": "46b46e5b-24da-4180-bfe2-2ef30b39d0d0",
+        "description": "93 is XCIII",
+        "comments": ["Because 90 is 100 - 10"],
+        "property": "roman",
+        "input": {
+          "number": 93
+        },
+        "expected": "XCIII"
+      },
+      {
+        "uuid": "30494be1-9afb-4f84-9d71-db9df18b55e3",
+        "description": "141 is CXLI",
+        "property": "roman",
+        "input": {
+          "number": 141
+        },
+        "expected": "CXLI"
+      },
+      {
+        "uuid": "267f0207-3c55-459a-b81d-67cec7a46ed9",
+        "description": "163 is CLXIII",
+        "comments": ["Because 60 is 50 + 10"],
+        "property": "roman",
+        "input": {
+          "number": 163
+        },
+        "expected": "CLXIII"
+      },
+      {
+        "uuid": "902ad132-0b4d-40e3-8597-ba5ed611dd8d",
+        "description": "166 is CLXVI",
+        "comments": [
+          "166 has exactly one occurence of all symbols whose value is less than 500 (D) in decreasing order"
+        ],
+        "property": "roman",
+        "input": {
+          "number": 166
+        },
+        "expected": "CLXVI"
+      },
+      {
+        "uuid": "cdb06885-4485-4d71-8bfb-c9d0f496b404",
+        "description": "402 is CDII",
+        "comments": ["Because 400 is 500 - 100"],
+        "property": "roman",
+        "input": {
+          "number": 402
+        },
+        "expected": "CDII"
+      },
+      {
+        "uuid": "6b71841d-13b2-46b4-ba97-dec28133ea80",
+        "description": "575 is DLXXV",
+        "property": "roman",
+        "input": {
+          "number": 575
+        },
+        "expected": "DLXXV"
+      },
+      {
+        "uuid": "dacb84b9-ea1c-4a61-acbb-ce6b36674906",
+        "description": "666 is DCLXVI",
+        "comments": [
+          "666 has exactly one occurence of all symbols whose value is less than 1000 (M) in decreasing order"
+        ],
+        "property": "roman",
+        "input": {
+          "number": 666
+        },
+        "expected": "DCLXVI"
+      },
+      {
+        "uuid": "432de891-7fd6-4748-a7f6-156082eeca2f",
+        "description": "911 is CMXI",
+        "comments": ["Because 900 is 1000 - 100"],
+        "property": "roman",
+        "input": {
+          "number": 911
+        },
+        "expected": "CMXI"
+      },
+      {
+        "uuid": "e6de6d24-f668-41c0-88d7-889c0254d173",
+        "description": "1024 is MXXIV",
+        "property": "roman",
+        "input": {
+          "number": 1024
+        },
+        "expected": "MXXIV"
+      },
+      {
+        "uuid": "efbe1d6a-9f98-4eb5-82bc-72753e3ac328",
+        "description": "1666 is MDCLXVI",
+        "comments": [
+          "1666 has exactly one occurence of all symbols in decreasing order"
+        ],
+        "property": "roman",
+        "input": {
+          "number": 1666
+        },
+        "expected": "MDCLXVI"
+      },
+      {
+        "uuid": "bb550038-d4eb-4be2-a9ce-f21961ac3bc6",
+        "description": "3000 is MMM",
+        "property": "roman",
+        "input": {
+          "number": 3000
+        },
+        "expected": "MMM"
+      },
+      {
+        "uuid": "3bc4b41c-c2e6-49d9-9142-420691504336",
+        "description": "3001 is MMMI",
+        "property": "roman",
+        "input": {
+          "number": 3001
+        },
+        "expected": "MMMI"
+      },
+      {
+        "uuid": "4e18e96b-5fbb-43df-a91b-9cb511fe0856",
+        "description": "3999 is MMMCMXCIX",
+        "property": "roman",
+        "input": {
+          "number": 3999
+        },
+        "expected": "MMMCMXCIX"
+      }
+    ]
+  }

--- a/roman-numerals/test-roman-numerals.http
+++ b/roman-numerals/test-roman-numerals.http
@@ -1,0 +1,19 @@
+{{
+    const loadTestData = require('../load-test-data');
+    exports.testCases = loadTestData('./roman-numerals/roman-numerals-test-cases.json');
+}}
+
+### Convert arabic numbers to roman numerals
+# @loop for testCase of testCases
+{{
+    httpRegion.metaData.title = testCase.description
+}}
+/api/roman-numerals?number={{testCase.number}}
+?? status == 200
+?? body roman == {{testCase.expected}}
+
+### Error when number is not specified
+/api/roman-numerals
+?? status == 400
+?? body message exists
+?? body message equals Please pass a number on the query string


### PR DESCRIPTION
This commit introduces setup for API tests using httpYac, including a GitHub Actions workflow and necessary scripts. Also, it adds a comprehensive set of test cases for the Roman numerals conversion functionality. The provided test cases cover a wide range of numbers and ensure accurate conversion from Arabic to Roman numerals. The http-client.env.json file was also added for environment configuration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a workflow for running API tests to ensure reliability.
	- Added configurations for different hosts, enhancing flexibility for local and cloud environments.
	- Implemented a function to load test data, supporting thorough testing processes.
	- Provided test cases for converting Arabic numbers to Roman numerals, demonstrating conversion logic.
- **Tests**
	- Added functionality to test the conversion of Arabic numbers to Roman numerals, ensuring accuracy and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->